### PR TITLE
Makes tables embedded in columns display better

### DIFF
--- a/src/css/master.css
+++ b/src/css/master.css
@@ -95,7 +95,7 @@ a.printindex {
 	color: black;
 }
 table {
-	display: inline-table;
+	display: block;
 	text-align: center;
 	border-collapse: collapse;
 	margin-top: 1em;


### PR DESCRIPTION
I promised to submit this PR almost two years ago and finally got around to it. I left out overflows-x because I don't have the time to test it to my satisfaction. Details below:
In elyxer's css that table display value is set to inline-table. The browser then creates a new rendering box within the parent box and render the table inside of the inner box.

The reason I care is because wordpress themes like to display content inside of a column whose width is flexible up to a maximum. So the column is the outer box and then a new inner box is created for the table. It makes the table look almost quoted.

The problem is that for some reason the browsers get stupid when set to inline table. They don't at all consider the size of the outer box (the column). So the table gets rendered in the inline table "inner box" without any kind of adaptive logic. Inevitably the table is too big to fit in the column (the outer box) and gets cut off.

But if I switch the display.table to block instead of inline-table then the table is rendered within the column and is aware of the column's width and adaptively renders the table to fit in that width if reasonably possible.

I actually throw in overflow-x set to auto to handle cases where the table is just way too big to fit in the column, in that case it will create a horizontal scroll bar.

I'm wondering if given how modern HTML rendering systems work if it wouldn't make more sense to change elyxer's table.display to block? I realize this isn't exactly how LYX would render it since tables tend to be indented.

It's not a big deal for me as I have my own copy of elyxer's css and just edited it. But I bet this would save a lot of frustration for other people.